### PR TITLE
fix: create version.js before TypeScript compilation in Docker build

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -7,18 +7,22 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm ci
 
-# Copy source code
-COPY . .
-
-# Generate API types first
-RUN npm run gen:api
-
 # Build the application with version info
 ARG VERSION=dev
 ARG BUILD_TIME=unknown
+
+# Copy source code
+COPY . .
+
+# Create version.js BEFORE TypeScript compilation
 RUN echo "export const version = \"${VERSION}\";" > src/version.js && \
-    echo "export const buildTime = \"${BUILD_TIME}\";" >> src/version.js && \
-    npm run build
+    echo "export const buildTime = \"${BUILD_TIME}\";" >> src/version.js
+
+# Generate API types
+RUN npm run gen:api
+
+# Build the application
+RUN npm run build
 
 # Production stage - serve static files with nginx
 FROM nginx:1.27-alpine


### PR DESCRIPTION
- Move version.js generation before npm run gen:api step
- Prevents TypeScript compilation errors when importing @version module
- Separate version.js creation and npm build into distinct RUN commands
- Improves build reliability by ensuring version module exists before type checking