### PR TITLE
feat: fix dropdown hover states and improve language switcher

### DIFF
--- a/web/src/common/components/DropdownMenu.module.css
+++ b/web/src/common/components/DropdownMenu.module.css
@@ -1,0 +1,43 @@
+/**
+ * DropdownMenu styles for dark header context
+ * Uses CSS modules to properly handle hover states (inline styles with &:hover don't work in Mantine v8)
+ * Uses Mantine CSS variables for theming consistency
+ */
+
+.dropdown {
+  background-color: #0f3460;
+  border-color: rgba(255, 255, 255, 0.1);
+}
+
+.arrow {
+  background-color: #0f3460;
+  border-color: rgba(255, 255, 255, 0.1);
+}
+
+.item {
+  color: white;
+}
+
+.item:hover,
+.item[data-hovered] {
+  background-color: color-mix(in srgb, var(--mantine-color-accent-5) 15%, transparent);
+  color: var(--mantine-color-accent-4);
+}
+
+.item:active {
+  background-color: color-mix(in srgb, var(--mantine-color-accent-5) 25%, transparent);
+}
+
+.itemLabel {
+  color: inherit;
+}
+
+.itemDanger {
+  color: var(--mantine-color-red-6);
+}
+
+.itemDanger:hover,
+.itemDanger[data-hovered] {
+  background-color: color-mix(in srgb, var(--mantine-color-red-5) 15%, transparent);
+  color: var(--mantine-color-red-4);
+}

--- a/web/src/common/components/DropdownMenu.tsx
+++ b/web/src/common/components/DropdownMenu.tsx
@@ -3,10 +3,10 @@ import {
   MenuTarget,
   MenuDropdown,
   MenuItem,
-  useMantineTheme,
   type MenuItemProps,
 } from '@mantine/core';
 import type { ReactNode } from 'react';
+import classes from './DropdownMenu.module.css';
 
 export interface DropdownMenuItem extends Omit<MenuItemProps, 'children' | 'key'> {
   key: string;
@@ -36,8 +36,6 @@ export function DropdownMenu({
   withArrow = true,
   shadow = 'md',
 }: DropdownMenuProps) {
-  const theme = useMantineTheme();
-
   return (
     <Menu
       position={position}
@@ -45,24 +43,11 @@ export function DropdownMenu({
       trigger={triggerAction}
       withArrow={withArrow}
       shadow={shadow}
-      styles={{
-        dropdown: {
-          backgroundColor: theme.other.layout.panelBg,
-          borderColor: theme.other.layout.lineLight,
-        },
-        arrow: {
-          backgroundColor: theme.other.layout.panelBg,
-          borderColor: theme.other.layout.lineLight,
-        },
-        item: {
-          color: 'white',
-          '&:hover': {
-            backgroundColor: theme.other.layout.bgHover,
-          },
-          '&:active': {
-            backgroundColor: theme.other.layout.bgActive,
-          },
-        },
+      classNames={{
+        dropdown: classes.dropdown,
+        arrow: classes.arrow,
+        item: classes.item,
+        itemLabel: classes.itemLabel,
       }}
     >
       <MenuTarget>{trigger}</MenuTarget>
@@ -76,11 +61,7 @@ export function DropdownMenu({
             href={item.href}
             target={item.href ? '_blank' : undefined}
             rel={item.href ? 'noopener noreferrer' : undefined}
-            styles={{
-              itemLabel: {
-                color: item.danger ? theme.colors.red[6] : 'white',
-              },
-            }}
+            className={item.danger ? classes.itemDanger : undefined}
           >
             {item.label}
           </MenuItem>

--- a/web/src/common/components/LanguageSwitcher.module.css
+++ b/web/src/common/components/LanguageSwitcher.module.css
@@ -1,0 +1,46 @@
+/**
+ * LanguageSwitcher styles for dark header context (compact variant)
+ * Uses CSS modules to properly handle hover states (inline styles with &:hover don't work in Mantine v8)
+ * Uses Mantine CSS variables for theming consistency
+ */
+
+.input {
+  background-color: rgba(15, 52, 96, 0.25);
+  border-color: rgba(255, 255, 255, 0.18);
+  color: white;
+  width: 140px;
+  padding-left: 12px;
+  padding-right: 14px;
+  font-weight: 600;
+  text-align: center;
+}
+
+.input:hover {
+  background-color: rgba(15, 52, 96, 0.45);
+}
+
+.input:focus,
+.input:focus-within {
+  background-color: rgba(15, 52, 96, 0.6);
+  border-color: rgba(255, 255, 255, 0.26);
+}
+
+.dropdown {
+  background-color: #0f3460;
+  border-color: rgba(255, 255, 255, 0.1);
+}
+
+.option {
+  color: white;
+}
+
+.option:hover,
+.option[data-hovered],
+.option[data-combobox-selected] {
+  background-color: color-mix(in srgb, var(--mantine-color-accent-5) 15%, transparent);
+  color: var(--mantine-color-accent-4);
+}
+
+.option[data-combobox-active] {
+  background-color: color-mix(in srgb, var(--mantine-color-accent-5) 25%, transparent);
+}

--- a/web/src/common/components/LanguageSwitcher.tsx
+++ b/web/src/common/components/LanguageSwitcher.tsx
@@ -1,7 +1,9 @@
-import { Text, Box, Select, useMantineTheme } from '@mantine/core';
+import { Text, Box, Select } from '@mantine/core';
+import { IconCheck } from '@tabler/icons-react';
 import { useLanguageSwitcher } from '@hooks/useTranslation';
 import { useTranslation } from 'react-i18next';
 import { Dropdown } from './Dropdown';
+import classes from './LanguageSwitcher.module.css';
 
 interface LanguageSwitcherProps {
   size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl';
@@ -12,56 +14,53 @@ export function LanguageSwitcher({ size = 'sm', variant = 'default' }: LanguageS
   const { t } = useTranslation('common');
   const { currentLanguage, availableLanguages, changeLanguage } = useLanguageSwitcher();
   const hasWipLanguages = availableLanguages.some((lang) => !lang.isStatic);
-  const theme = useMantineTheme();
 
   // Compact mode for dashboard header
   if (variant === 'compact') {
-    const staticLanguages = availableLanguages.filter(lang => lang.isStatic);
+    const selectData = availableLanguages
+      .filter(lang => lang.isStatic || lang.code === '__separator__')
+      .map((lang) => ({
+        value: lang.code,
+        label: lang.name,
+        disabled: lang.code === '__separator__',
+      }));
     
     return (
       <Select
-        data={staticLanguages.map((lang) => ({
-          value: lang.code,
-          label: lang.name,
-        }))}
+        data={selectData}
         value={currentLanguage.code}
         onChange={(value) => {
-          if (!value) return;
+          if (!value || value === '__separator__') return;
           void changeLanguage(value);
         }}
         size="sm"
-        styles={{
-          input: {
-            backgroundColor: theme.other.layout.bgSubtle,
-            borderColor: theme.other.layout.borderSubtle,
-            color: 'white',
-            width: '140px',
-            paddingLeft: '12px',
-            paddingRight: '14px',
-            fontWeight: 600,
-            textAlign: 'center',
-            '&:hover': {
-              backgroundColor: theme.other.layout.bgHover,
-            },
-            '&:focus': {
-              backgroundColor: theme.other.layout.bgActive,
-              borderColor: theme.other.layout.borderStrong,
-            },
-            '&:focusWithin': {
-              backgroundColor: theme.other.layout.bgActive,
-              borderColor: theme.other.layout.borderStrong,
-            },
-          },
-          dropdown: {
-            backgroundColor: theme.other.layout.panelBg,
-            borderColor: theme.other.layout.lineLight,
-          },
-          option: {
-            color: 'white',
-            '&:hover': {
-              backgroundColor: theme.other.layout.bgHover,
-            },
-          },
+        classNames={{
+          input: classes.input,
+          dropdown: classes.dropdown,
+          option: classes.option,
+        }}
+        renderOption={({ option }) => {
+          if (option.value === '__separator__') {
+            return (
+              <Box style={{ 
+                textAlign: 'center', 
+                color: 'rgba(255, 255, 255, 0.3)',
+                cursor: 'default',
+                userSelect: 'none',
+              }}>
+                {option.label}
+              </Box>
+            );
+          }
+          
+          return (
+            <Box style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', width: '100%' }}>
+              <span>{option.label}</span>
+              {option.value === currentLanguage.code && (
+                <IconCheck size={16} color="var(--mantine-color-green-5)" />
+              )}
+            </Box>
+          );
         }}
       />
     );

--- a/web/src/common/hooks/useTranslation.ts
+++ b/web/src/common/hooks/useTranslation.ts
@@ -46,13 +46,25 @@ export const useLanguageSwitcher = () => {
     await i18n.changeLanguage(language);
   };
 
-  const availableLanguages = languagesData.map((lang) => ({
+  const allLanguages = languagesData.map((lang) => ({
     code: lang.code,
     name: lang.label,
     isStatic: isStaticLanguage(lang.code),
   }));
 
-  const currentLanguage = availableLanguages.find(lang => lang.code === i18n.language) || availableLanguages[0];
+  // Sort: English, Deutsch first, then separator, then others alphabetically
+  const priorityLanguages = allLanguages.filter(lang => lang.code === 'en' || lang.code === 'de');
+  const otherLanguages = allLanguages
+    .filter(lang => lang.code !== 'en' && lang.code !== 'de')
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  const availableLanguages = [
+    ...priorityLanguages.sort((a) => a.code === 'en' ? -1 : 1), // en first, then de
+    { code: '__separator__', name: '───────────', isStatic: false },
+    ...otherLanguages,
+  ];
+
+  const currentLanguage = allLanguages.find(lang => lang.code === i18n.language) || allLanguages[0];
 
   return {
     currentLanguage,


### PR DESCRIPTION
- Replace inline styles with CSS modules for proper hover states in Mantine v8
- Add cyan accent hover colors using theme CSS variables
- Sort languages: English, Deutsch first, then separator, then alphabetically
- Add green checkmark to currently selected language
- Use #0f3460 background for dropdowns matching header gradient