### PR TITLE
fix: prepend https:// to HOMEPAGE_URL and redirect on missing backend user

### DIFF
--- a/web/src/common/lib/url.ts
+++ b/web/src/common/lib/url.ts
@@ -66,7 +66,12 @@ export function getCookiePath(): string {
  */
 export function getHomepageUrl(): string {
   if (config.HOMEPAGE_URL) {
-    return config.HOMEPAGE_URL;
+    const url = config.HOMEPAGE_URL;
+    // Ensure the URL has a protocol so it's treated as absolute, not relative
+    if (!url.startsWith('http://') && !url.startsWith('https://')) {
+      return `https://${url}`;
+    }
+    return url;
   }
   return buildShareUrl(ROUTES.HOME);
 }

--- a/web/src/routes/__root.tsx
+++ b/web/src/routes/__root.tsx
@@ -90,6 +90,11 @@ function RootComponent() {
   const shouldRedirect =
     !isLoading && !isAuthenticated && !isPublicRoute && !needsRegistration;
 
+  // Authenticated (e.g. Auth0 session) but backend user not available —
+  // redirect to homepage instead of rendering pages without a header
+  const shouldRedirectNoBackendUser =
+    !isLoading && isAuthenticated && !backendUser && !needsRegistration && !isPublicRoute;
+
   // Redirect participants to my-workshop if they try to access other routes
   const shouldRedirectParticipant =
     !isLoading && isParticipant && !isPublicRoute && !isParticipantAllowedRoute;
@@ -122,6 +127,17 @@ function RootComponent() {
       navigate({ to: ROUTES.MY_WORKSHOP as "/" });
     }
   }, [shouldRedirectWorkshopMode, navigate]);
+
+  // Redirect to homepage when authenticated but backend user unavailable
+  useEffect(() => {
+    if (shouldRedirectNoBackendUser) {
+      if (hasExternalHomepage()) {
+        window.location.href = getHomepageUrl();
+      } else {
+        navigate({ to: ROUTES.HOME });
+      }
+    }
+  }, [shouldRedirectNoBackendUser, navigate]);
 
   // Organization/Workshop permissions - needed early for nav items
   const userInstitutionId = getUserInstitutionId(backendUser);
@@ -364,6 +380,17 @@ function RootComponent() {
 
   // Show loading while redirecting
   if (shouldRedirect) {
+    return (
+      <AppLayout variant="public">
+        <Center h="50vh">
+          <Loader size="lg" />
+        </Center>
+      </AppLayout>
+    );
+  }
+
+  // Authenticated but no backend user — show loader while redirecting to homepage
+  if (shouldRedirectNoBackendUser) {
     return (
       <AppLayout variant="public">
         <Center h="50vh">


### PR DESCRIPTION
getHomepageUrl now adds https:// when HOMEPAGE_URL lacks a protocol,
fixing the broken redirect to /chatgamelab.eu instead of
https://chatgamelab.eu.

Also redirect to homepage when authenticated (Auth0 session) but
backend user is unavailable, instead of showing the dashboard
without a header.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
