### PR TITLE
refactor: split / into routing hub + /landing page

### DIFF
--- a/web/src/common/routes/routes.ts
+++ b/web/src/common/routes/routes.ts
@@ -12,6 +12,7 @@
 export const ROUTES = {
   // Core pages
   HOME: "/",
+  LANDING: "/landing",
   DASHBOARD: "/dashboard",
   PROFILE: "/profile",
   SETTINGS: "/settings",
@@ -74,7 +75,7 @@ export const ROUTES = {
 
 // Route groups for navigation menus
 export const NAVIGATION_GROUPS = {
-  MAIN: [ROUTES.HOME, ROUTES.DASHBOARD],
+  MAIN: [ROUTES.HOME, ROUTES.LANDING, ROUTES.DASHBOARD],
   AUTH: [ROUTES.AUTH_LOGIN, ROUTES.AUTH_REGISTER],
   USER: [ROUTES.PROFILE, ROUTES.SETTINGS, ROUTES.API_KEYS],
   MY_GAMES: [ROUTES.MY_GAMES],

--- a/web/src/providers/AuthProvider.tsx
+++ b/web/src/providers/AuthProvider.tsx
@@ -405,11 +405,13 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       });
     } else if (isParticipant) {
       authLogger.debug("Logging out participant (clearing session and token)");
+      // Keep isLoading true to prevent __root.tsx shouldRedirect from firing
+      // before window.location.href takes effect
+      setIsLoading(true);
       setUser(null);
       setBackendUser(null);
       setIsAuthenticated(false);
       setIsParticipant(false);
-      setIsLoading(false);
       backendFetchAttempted.current = false;
       clearParticipantToken();
       try {
@@ -430,12 +432,14 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       window.location.href = homepageUrl;
     } else {
       authLogger.debug("Logging out from dev mode");
+      // Keep isLoading true to prevent __root.tsx shouldRedirect from firing
+      // before window.location.href takes effect
+      setIsLoading(true);
       devTokenCache.current = null;
       clearStoredDevToken();
       setUser(null);
       setIsAuthenticated(false);
       setIsParticipant(false);
-      setIsLoading(false);
       const homepageUrl = getHomepageUrl();
       authLogger.debug("Redirecting to homepage after logout", {
         url: homepageUrl,

--- a/web/src/routeTree.gen.ts
+++ b/web/src/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as SettingsRouteImport } from './routes/settings'
 import { Route as ProfileRouteImport } from './routes/profile'
+import { Route as LandingRouteImport } from './routes/landing'
 import { Route as DashboardRouteImport } from './routes/dashboard'
 import { Route as ApiKeysRouteImport } from './routes/api-keys'
 import { Route as IndexRouteImport } from './routes/index'
@@ -50,6 +51,11 @@ const SettingsRoute = SettingsRouteImport.update({
 const ProfileRoute = ProfileRouteImport.update({
   id: '/profile',
   path: '/profile',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const LandingRoute = LandingRouteImport.update({
+  id: '/landing',
+  path: '/landing',
   getParentRoute: () => rootRouteImport,
 } as any)
 const DashboardRoute = DashboardRouteImport.update({
@@ -208,6 +214,7 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/api-keys': typeof ApiKeysRoute
   '/dashboard': typeof DashboardRoute
+  '/landing': typeof LandingRoute
   '/profile': typeof ProfileRoute
   '/settings': typeof SettingsRoute
   '/creations/$gameId': typeof CreationsGameIdRoute
@@ -242,6 +249,7 @@ export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/api-keys': typeof ApiKeysRoute
   '/dashboard': typeof DashboardRoute
+  '/landing': typeof LandingRoute
   '/profile': typeof ProfileRoute
   '/settings': typeof SettingsRoute
   '/creations/$gameId': typeof CreationsGameIdRoute
@@ -277,6 +285,7 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/api-keys': typeof ApiKeysRoute
   '/dashboard': typeof DashboardRoute
+  '/landing': typeof LandingRoute
   '/profile': typeof ProfileRoute
   '/settings': typeof SettingsRoute
   '/creations/$gameId': typeof CreationsGameIdRoute
@@ -313,6 +322,7 @@ export interface FileRouteTypes {
     | '/'
     | '/api-keys'
     | '/dashboard'
+    | '/landing'
     | '/profile'
     | '/settings'
     | '/creations/$gameId'
@@ -347,6 +357,7 @@ export interface FileRouteTypes {
     | '/'
     | '/api-keys'
     | '/dashboard'
+    | '/landing'
     | '/profile'
     | '/settings'
     | '/creations/$gameId'
@@ -381,6 +392,7 @@ export interface FileRouteTypes {
     | '/'
     | '/api-keys'
     | '/dashboard'
+    | '/landing'
     | '/profile'
     | '/settings'
     | '/creations/$gameId'
@@ -416,6 +428,7 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   ApiKeysRoute: typeof ApiKeysRoute
   DashboardRoute: typeof DashboardRoute
+  LandingRoute: typeof LandingRoute
   ProfileRoute: typeof ProfileRoute
   SettingsRoute: typeof SettingsRoute
   CreationsGameIdRoute: typeof CreationsGameIdRoute
@@ -461,6 +474,13 @@ declare module '@tanstack/react-router' {
       path: '/profile'
       fullPath: '/profile'
       preLoaderRoute: typeof ProfileRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/landing': {
+      id: '/landing'
+      path: '/landing'
+      fullPath: '/landing'
+      preLoaderRoute: typeof LandingRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/dashboard': {
@@ -680,6 +700,7 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   ApiKeysRoute: ApiKeysRoute,
   DashboardRoute: DashboardRoute,
+  LandingRoute: LandingRoute,
   ProfileRoute: ProfileRoute,
   SettingsRoute: SettingsRoute,
   CreationsGameIdRoute: CreationsGameIdRoute,

--- a/web/src/routes/__root.tsx
+++ b/web/src/routes/__root.tsx
@@ -22,7 +22,6 @@ import { useWorkshopMode } from "../providers/WorkshopModeProvider";
 import { RegistrationForm } from "../features/auth";
 import { useLocation } from "@tanstack/react-router";
 import { ROUTES } from "../common/routes/routes";
-import { hasExternalHomepage, getHomepageUrl } from "../common/lib/url";
 import {
   isAdmin,
   getUserInstitutionId,
@@ -67,10 +66,13 @@ function RootComponent() {
     isGuestPlayRoute;
 
   // Public routes that don't require authentication
+  const isLandingPage = pathname === ROUTES.LANDING;
   const isPublicRoute =
     isHomePage ||
+    isLandingPage ||
     pathname.startsWith(ROUTES.AUTH_LOGIN) ||
     pathname.startsWith(ROUTES.AUTH_REGISTER) ||
+    pathname.startsWith(ROUTES.AUTH_LOGOUT) ||
     pathname.startsWith(ROUTES.INVITES) ||
     isGuestPlayRoute;
 
@@ -83,7 +85,7 @@ function RootComponent() {
   // Determine layout variant based on auth state
   const isFullyAuthenticated =
     isAuthenticated && backendUser && !needsRegistration;
-  const useAuthenticatedLayout = isFullyAuthenticated && !isHomePage;
+  const useAuthenticatedLayout = isFullyAuthenticated && !isHomePage && !isLandingPage;
 
   // Redirect to homepage only if NOT authenticated (not just waiting for backend user)
   // If authenticated but backendUser is still loading, keep showing loader instead of redirecting
@@ -106,11 +108,8 @@ function RootComponent() {
   // All hooks must be called before any early returns
   useEffect(() => {
     if (shouldRedirect) {
-      if (hasExternalHomepage()) {
-        window.location.href = getHomepageUrl();
-      } else {
-        navigate({ to: ROUTES.HOME });
-      }
+      // Always go to / — the routing hub decides where to send the user
+      navigate({ to: ROUTES.HOME });
     }
   }, [shouldRedirect, navigate]);
 
@@ -131,11 +130,7 @@ function RootComponent() {
   // Redirect to homepage when authenticated but backend user unavailable
   useEffect(() => {
     if (shouldRedirectNoBackendUser) {
-      if (hasExternalHomepage()) {
-        window.location.href = getHomepageUrl();
-      } else {
-        navigate({ to: ROUTES.HOME });
-      }
+      navigate({ to: ROUTES.HOME });
     }
   }, [shouldRedirectNoBackendUser, navigate]);
 
@@ -411,7 +406,7 @@ function RootComponent() {
         variant={useAuthenticatedLayout ? "authenticated" : "public"}
         navItems={useAuthenticatedLayout ? navItems : undefined}
         background={layoutBackground}
-        transparentFooter={isHomePage}
+        transparentFooter={isHomePage || isLandingPage}
         headerProps={headerProps}
         darkMode={isGamePlayerRoute}
         withContainer={!isGamePlayerRoute}

--- a/web/src/routes/auth/login/index.tsx
+++ b/web/src/routes/auth/login/index.tsx
@@ -22,10 +22,10 @@ function LoginComponent() {
   const { loginWithAuth0, loginWithRole, isDevMode, user } = useAuth();
   const router = useRouter();
 
-  // Redirect to dashboard if already authenticated
+  // Redirect authenticated users — routing hub decides where to go
   useEffect(() => {
     if (user) {
-      router.navigate({ to: ROUTES.DASHBOARD });
+      router.navigate({ to: ROUTES.HOME });
     }
   }, [user, router]);
 

--- a/web/src/routes/auth/logout/auth0/callback.tsx
+++ b/web/src/routes/auth/logout/auth0/callback.tsx
@@ -3,7 +3,6 @@ import { useEffect } from 'react';
 import { Center, Loader, Text } from '@mantine/core';
 import { ROUTES } from '@/common/routes/routes';
 import { authLogger } from '@/config/logger';
-import { hasExternalHomepage, getHomepageUrl } from '@/common/lib/url';
 
 export const Route = createFileRoute('/auth/logout/auth0/callback')({
   component: Auth0LogoutCallback,
@@ -16,20 +15,11 @@ function Auth0LogoutCallback() {
     const handleLogoutCallback = () => {
       try {
         authLogger.debug('Processing logout callback completion');
-
-        // Redirect to external homepage if configured, otherwise built-in home
-        if (hasExternalHomepage()) {
-          window.location.href = getHomepageUrl();
-        } else {
-          navigate({ to: ROUTES.HOME });
-        }
+        // Navigate to routing hub — it decides where the user should go
+        navigate({ to: ROUTES.HOME });
       } catch (err) {
         authLogger.error('Auth0 logout callback error', { error: err });
-        if (hasExternalHomepage()) {
-          window.location.href = getHomepageUrl();
-        } else {
-          navigate({ to: ROUTES.HOME });
-        }
+        navigate({ to: ROUTES.HOME });
       }
     };
 

--- a/web/src/routes/auth/register/index.tsx
+++ b/web/src/routes/auth/register/index.tsx
@@ -49,10 +49,10 @@ function RegisterComponent() {
   const [educatorModalOpened, { open: openEducatorModal, close: closeEducatorModal }] =
     useDisclosure(false);
 
-  // Redirect to dashboard if already authenticated
+  // Redirect authenticated users — routing hub decides where to go
   useEffect(() => {
     if (user) {
-      router.navigate({ to: ROUTES.DASHBOARD });
+      router.navigate({ to: ROUTES.HOME });
     }
   }, [user, router]);
 

--- a/web/src/routes/index.tsx
+++ b/web/src/routes/index.tsx
@@ -1,196 +1,40 @@
-import { createFileRoute, useRouter } from "@tanstack/react-router";
-import {
-  Stack,
-  Center,
-  Image,
-  Container,
-  SimpleGrid,
-  Card,
-  Group,
-  ThemeIcon,
-  Box,
-  useMantineTheme,
-} from "@mantine/core";
-import { useTranslation } from "react-i18next";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { Center, Loader } from "@mantine/core";
 import { useEffect } from "react";
-import { ActionButton } from "@components/buttons";
-import { SectionTitle, CardTitle, BodyText } from "@components/typography";
-import { LanguageSwitcher } from "@components/LanguageSwitcher";
-import {
-  IconBook,
-  IconUsers,
-  IconSchool,
-  IconSparkles,
-  IconRocket,
-  IconLogin,
-} from "@tabler/icons-react";
-import logo from "@/assets/logos/colorful/ChatGameLab-Logo-2025-Square-Colorful2-Black-Text.png-Black-Text-Transparent.png";
 import { ROUTES } from "@/common/routes/routes";
 import { hasExternalHomepage, getHomepageUrl } from "@/common/lib/url";
 import { useAuth } from "@/providers/AuthProvider";
 
 export const Route = createFileRoute(ROUTES.HOME)({
-  component: HomePage,
+  component: HomeRouter,
 });
 
-function HomePage() {
-  const { t } = useTranslation("common");
-  const router = useRouter();
-  const theme = useMantineTheme();
-  const { user } = useAuth();
+/**
+ * Pure routing hub — decides where the user should go:
+ * - External homepage configured → redirect there
+ * - Authenticated → dashboard
+ * - Not authenticated → /landing (built-in landing page)
+ */
+function HomeRouter() {
+  const { isAuthenticated, isLoading } = useAuth();
+  const navigate = useNavigate();
 
-  // If an external homepage is configured, redirect there immediately
   useEffect(() => {
+    if (isLoading) return;
+
     if (hasExternalHomepage()) {
+      // External homepage: always redirect there (logged-in users go to dashboard via the external site)
       window.location.href = getHomepageUrl();
+    } else if (isAuthenticated) {
+      navigate({ to: ROUTES.DASHBOARD });
+    } else {
+      navigate({ to: ROUTES.LANDING as "/" });
     }
-  }, []);
-
-  // Redirect to dashboard if already authenticated
-  useEffect(() => {
-    if (user) {
-      router.navigate({ to: ROUTES.DASHBOARD });
-    }
-  }, [user, router]);
-
-  const features = [
-    {
-      icon: IconBook,
-      title: t("home.features.create.title", "Create Adventures"),
-      description: t(
-        "home.features.create.description",
-        "Design interactive text adventures powered by AI",
-      ),
-    },
-    {
-      icon: IconSparkles,
-      title: t("home.features.understand.title", "Understand AI"),
-      description: t(
-        "home.features.understand.description",
-        "Explore how AI models create stories and learn how they work",
-      ),
-    },
-    {
-      icon: IconSchool,
-      title: t("home.features.learn.title", "Learn & Teach"),
-      description: t(
-        "home.features.learn.description",
-        "Perfect for educational workshops and classroom activities",
-      ),
-    },
-    {
-      icon: IconUsers,
-      title: t("home.features.play.title", "Play Together"),
-      description: t(
-        "home.features.play.description",
-        "Join friends in collaborative storytelling sessions",
-      ),
-    },
-  ];
+  }, [isLoading, isAuthenticated, navigate]);
 
   return (
-    <Box>
-      {/* Hero Section */}
-      <Container size="xl" px={{ base: "sm", sm: "md", lg: "xl" }}>
-        <Stack gap="xl" py="md" mt="-sm">
-          <Group justify="space-between" align="center">
-            <Box />
-            <LanguageSwitcher size="sm" variant="subtle" />
-          </Group>
-
-          <Center>
-            <Stack gap="xl" align="center" ta="center" maw={800}>
-              <Image
-                src={logo}
-                alt="ChatGameLab Logo"
-                w={{ base: 200, sm: 280, lg: 350 }}
-                h={{ base: 200, sm: 280, lg: 350 }}
-                fit="contain"
-              />
-
-              <BodyText size="xl">
-                {t(
-                  "home.splashDescription",
-                  "An educational platform for creating and playing AI-powered text-adventure games. Perfect for teachers, students, and creative storytellers.",
-                )}
-              </BodyText>
-
-              <Group gap="md" justify="center">
-                <ActionButton
-                  onClick={() => {
-                    router.navigate({ to: ROUTES.AUTH_REGISTER });
-                  }}
-                  leftSection={<IconRocket size={20} />}
-                  size="md"
-                >
-                  {t("home.registerCta", "Register")}
-                </ActionButton>
-                <ActionButton
-                  onClick={() => {
-                    router.navigate({ to: ROUTES.AUTH_LOGIN });
-                  }}
-                  leftSection={<IconLogin size={20} />}
-                  size="md"
-                  color="gray"
-                >
-                  {t("home.loginCta", "Log in")}
-                </ActionButton>
-              </Group>
-            </Stack>
-          </Center>
-
-          {/* Features Section */}
-          <Stack gap="xl" mt="xl">
-            <Stack gap="md" align="center" ta="center">
-              <SectionTitle accent>
-                {t("home.features.title", "Why Choose ChatGameLab?")}
-              </SectionTitle>
-            </Stack>
-
-            <SimpleGrid
-              cols={{ base: 1, sm: 2, lg: 4 }}
-              spacing={{ base: "lg", sm: "xl" }}
-              verticalSpacing={{ base: "lg", sm: "xl" }}
-            >
-              {features.map((feature, index) => (
-                <Card
-                  key={index}
-                  shadow="md"
-                  p="lg"
-                  radius="md"
-                  withBorder={false}
-                  h="100%"
-                  bg={theme.other.colors.bgCard}
-                  style={{
-                    transition: "all 0.3s ease",
-                    border: `1px solid ${theme.other.colors.bgCardBorder}`,
-                  }}
-                >
-                  <Stack gap="md" align="center" ta="center">
-                    <ThemeIcon
-                      size="xl"
-                      radius="xl"
-                      color="accent"
-                      variant="light"
-                    >
-                      <feature.icon size={24} />
-                    </ThemeIcon>
-
-                    <CardTitle accent>
-                      {feature.title}
-                    </CardTitle>
-
-                    <BodyText size="sm">
-                      {feature.description}
-                    </BodyText>
-                  </Stack>
-                </Card>
-              ))}
-            </SimpleGrid>
-          </Stack>
-
-        </Stack>
-      </Container>
-    </Box>
+    <Center h="50vh">
+      <Loader size="lg" />
+    </Center>
   );
 }

--- a/web/src/routes/landing.tsx
+++ b/web/src/routes/landing.tsx
@@ -1,0 +1,196 @@
+import { createFileRoute, useRouter } from "@tanstack/react-router";
+import {
+  Stack,
+  Center,
+  Image,
+  Container,
+  SimpleGrid,
+  Card,
+  Group,
+  ThemeIcon,
+  Box,
+  useMantineTheme,
+} from "@mantine/core";
+import { useTranslation } from "react-i18next";
+import { useEffect } from "react";
+import { ActionButton } from "@components/buttons";
+import { SectionTitle, CardTitle, BodyText } from "@components/typography";
+import { LanguageSwitcher } from "@components/LanguageSwitcher";
+import {
+  IconBook,
+  IconUsers,
+  IconSchool,
+  IconSparkles,
+  IconRocket,
+  IconLogin,
+} from "@tabler/icons-react";
+import logo from "@/assets/logos/colorful/ChatGameLab-Logo-2025-Square-Colorful2-Black-Text.png-Black-Text-Transparent.png";
+import { ROUTES } from "@/common/routes/routes";
+import { hasExternalHomepage, getHomepageUrl } from "@/common/lib/url";
+import { useAuth } from "@/providers/AuthProvider";
+
+export const Route = createFileRoute("/landing")({
+  component: LandingPage,
+});
+
+function LandingPage() {
+  const { t } = useTranslation("common");
+  const router = useRouter();
+  const theme = useMantineTheme();
+  const { user } = useAuth();
+
+  // If external homepage is configured, this page should never be shown — redirect
+  useEffect(() => {
+    if (hasExternalHomepage()) {
+      window.location.href = getHomepageUrl();
+    }
+  }, []);
+
+  // Redirect to dashboard if already authenticated
+  useEffect(() => {
+    if (user) {
+      router.navigate({ to: ROUTES.DASHBOARD });
+    }
+  }, [user, router]);
+
+  const features = [
+    {
+      icon: IconBook,
+      title: t("home.features.create.title", "Create Adventures"),
+      description: t(
+        "home.features.create.description",
+        "Design interactive text adventures powered by AI",
+      ),
+    },
+    {
+      icon: IconSparkles,
+      title: t("home.features.understand.title", "Understand AI"),
+      description: t(
+        "home.features.understand.description",
+        "Explore how AI models create stories and learn how they work",
+      ),
+    },
+    {
+      icon: IconSchool,
+      title: t("home.features.learn.title", "Learn & Teach"),
+      description: t(
+        "home.features.learn.description",
+        "Perfect for educational workshops and classroom activities",
+      ),
+    },
+    {
+      icon: IconUsers,
+      title: t("home.features.play.title", "Play Together"),
+      description: t(
+        "home.features.play.description",
+        "Join friends in collaborative storytelling sessions",
+      ),
+    },
+  ];
+
+  return (
+    <Box>
+      {/* Hero Section */}
+      <Container size="xl" px={{ base: "sm", sm: "md", lg: "xl" }}>
+        <Stack gap="xl" py="md" mt="-sm">
+          <Group justify="space-between" align="center">
+            <Box />
+            <LanguageSwitcher size="sm" variant="subtle" />
+          </Group>
+
+          <Center>
+            <Stack gap="xl" align="center" ta="center" maw={800}>
+              <Image
+                src={logo}
+                alt="ChatGameLab Logo"
+                w={{ base: 200, sm: 280, lg: 350 }}
+                h={{ base: 200, sm: 280, lg: 350 }}
+                fit="contain"
+              />
+
+              <BodyText size="xl">
+                {t(
+                  "home.splashDescription",
+                  "An educational platform for creating and playing AI-powered text-adventure games. Perfect for teachers, students, and creative storytellers.",
+                )}
+              </BodyText>
+
+              <Group gap="md" justify="center">
+                <ActionButton
+                  onClick={() => {
+                    router.navigate({ to: ROUTES.AUTH_REGISTER });
+                  }}
+                  leftSection={<IconRocket size={20} />}
+                  size="md"
+                >
+                  {t("home.registerCta", "Register")}
+                </ActionButton>
+                <ActionButton
+                  onClick={() => {
+                    router.navigate({ to: ROUTES.AUTH_LOGIN });
+                  }}
+                  leftSection={<IconLogin size={20} />}
+                  size="md"
+                  color="gray"
+                >
+                  {t("home.loginCta", "Log in")}
+                </ActionButton>
+              </Group>
+            </Stack>
+          </Center>
+
+          {/* Features Section */}
+          <Stack gap="xl" mt="xl">
+            <Stack gap="md" align="center" ta="center">
+              <SectionTitle accent>
+                {t("home.features.title", "Why Choose ChatGameLab?")}
+              </SectionTitle>
+            </Stack>
+
+            <SimpleGrid
+              cols={{ base: 1, sm: 2, lg: 4 }}
+              spacing={{ base: "lg", sm: "xl" }}
+              verticalSpacing={{ base: "lg", sm: "xl" }}
+            >
+              {features.map((feature, index) => (
+                <Card
+                  key={index}
+                  shadow="md"
+                  p="lg"
+                  radius="md"
+                  withBorder={false}
+                  h="100%"
+                  bg={theme.other.colors.bgCard}
+                  style={{
+                    transition: "all 0.3s ease",
+                    border: `1px solid ${theme.other.colors.bgCardBorder}`,
+                  }}
+                >
+                  <Stack gap="md" align="center" ta="center">
+                    <ThemeIcon
+                      size="xl"
+                      radius="xl"
+                      color="accent"
+                      variant="light"
+                    >
+                      <feature.icon size={24} />
+                    </ThemeIcon>
+
+                    <CardTitle accent>
+                      {feature.title}
+                    </CardTitle>
+
+                    <BodyText size="sm">
+                      {feature.description}
+                    </BodyText>
+                  </Stack>
+                </Card>
+              ))}
+            </SimpleGrid>
+          </Stack>
+
+        </Stack>
+      </Container>
+    </Box>
+  );
+}


### PR DESCRIPTION
/ is now a pure routing hub that decides where to redirect:
- External homepage configured → redirect there
- Authenticated → /dashboard
- Not authenticated → /landing (built-in landing page)

This fixes several redirect issues:
- No more flash of landing page before external homepage redirect
- No more redirect loop on logout (dashboard → / → dashboard)
- Auth logout callback added to public routes
- Logout sets isLoading=true to prevent shouldRedirect race condition
- Login/register redirect to / (hub) instead of directly to /dashboard
