### PR TITLE
fix(web): remove dead space below game lists

### DIFF
--- a/web/src/common/components/Layout/AppLayout.css
+++ b/web/src/common/components/Layout/AppLayout.css
@@ -1,0 +1,31 @@
+/* Usable height of a page rendered inside AppLayout: the viewport minus the
+   header, the footer and all layout padding.
+
+   Full-height pages (game lists, workshop) used to hardcode this as
+   `calc(100vh - 280px)`. The real chrome on desktop is 208px, so those pages
+   came out 72px short and left a dead strip above the footer — roughly one
+   game row that silently went missing.
+
+   Header, footer and AppShell padding come from AppShell's own variables, so
+   they follow whatever AppLayout configures. Only --app-content-inset is ours:
+   the extra top padding AppLayout adds on top of the header (10px / 20px) plus
+   the Container's vertical padding (2 x 12px / 2 x 16px). Keep it in sync with
+   AppLayout.tsx.
+
+   dvh rather than vh so mobile browsers collapsing their toolbars don't
+   overshoot the viewport. */
+:root {
+  --app-content-inset: 34px;
+  --app-content-height: calc(
+    100dvh - var(--app-shell-header-offset, 0px) -
+      var(--app-shell-footer-offset, 0px) - var(--app-shell-padding, 0px) -
+      var(--app-content-inset)
+  );
+}
+
+/* Mantine breakpoint sm */
+@media (min-width: 48em) {
+  :root {
+    --app-content-inset: 52px;
+  }
+}

--- a/web/src/common/components/Layout/AppLayout.tsx
+++ b/web/src/common/components/Layout/AppLayout.tsx
@@ -1,4 +1,5 @@
 import { AppShell, Container } from "@mantine/core";
+import "./AppLayout.css";
 import {
   AppHeader,
   type AppHeaderProps,
@@ -22,6 +23,10 @@ export interface AppLayoutProps {
 
 const HEADER_HEIGHT = { base: 60, sm: 80 } as const;
 const FOOTER_HEIGHT = { base: 50, sm: 60 } as const;
+
+// NOTE: the extra top padding below (+10 / +20) and the Container's py add up to
+// `--app-content-inset` in AppLayout.css, which full-height pages use to size
+// themselves via `--app-content-height`. Change one, change the other.
 
 export function AppLayout({
   children,

--- a/web/src/features/games/components/AllGames.tsx
+++ b/web/src/features/games/components/AllGames.tsx
@@ -594,7 +594,7 @@ export function AllGames() {
     <>
       <Stack
         gap="lg"
-        h={{ base: "calc(100vh - 130px)", sm: "calc(100vh - 280px)" }}
+        h="var(--app-content-height)"
         style={{ overflow: "hidden" }}
       >
         {/* Sticky header section */}

--- a/web/src/features/games/components/MyGames.tsx
+++ b/web/src/features/games/components/MyGames.tsx
@@ -555,7 +555,7 @@ export function MyGames({
     <>
       <Stack
         gap="lg"
-        h={{ base: "calc(100vh - 130px)", sm: "calc(100vh - 280px)" }}
+        h="var(--app-content-height)"
         style={{ overflow: "hidden" }}
       >
         {/* Sticky header section */}

--- a/web/src/features/my-workshop/components/MyWorkshop.tsx
+++ b/web/src/features/my-workshop/components/MyWorkshop.tsx
@@ -520,7 +520,7 @@ export function MyWorkshop() {
     <>
       <Stack
         gap="lg"
-        h={{ base: "calc(100vh - 130px)", sm: "calc(100vh - 280px)" }}
+        h="var(--app-content-height)"
         style={{ overflow: "hidden", position: "relative" }}
       >
         {isPausedForUser && <WorkshopPausedOverlay />}


### PR DESCRIPTION
## Problem

The full-height pages — **My Games**, **All Games**, **My Workshop** — size their content with a hardcoded `calc(100vh - 280px)`. The actual layout chrome around them is only **208px** on desktop, so the list container comes out **72px short** and leaves an unusable strip between the list and the footer. That's roughly one game row (63px) that silently goes missing: with 4 games in the list it can look like there are only 2.

Mobile had the same problem with the `130px` value, off by 24px.

## Measured on `/games` at 1280x720

| | before | after |
|---|---|---|
| container height | 440px | 512px |
| dead strip above footer | **72px** | **0px** |
| test games visible (of 5) | 4, scrolling | 5, no scroll |

## Fix

Derive the height from AppShell's own `--app-shell-header-offset`, `--app-shell-footer-offset` and `--app-shell-padding` instead of guessing it, via a new `--app-content-height` custom property owned by `AppLayout`. Only the padding `AppLayout` itself adds on top (`--app-content-inset`) stays as a number, now in one place instead of scattered across three components.

Also switches `vh` -> `dvh` so mobile browsers collapsing their toolbars don't overshoot.

## Note for review

The variable initially went into `web/src/index.css`, which turns out to be **never imported** — leftover Vite boilerplate, along with `App.css` and `App.tsx`. Only the three `@mantine/*/styles.css` imports in `main.tsx` are loaded globally. Hence the new `AppLayout.css` next to the component that owns the layout.

Worth knowing separately: `index.css` also holds an intentional fix against iOS Safari auto-zoom on input focus, which has therefore never been active. Left out of this PR — happy to do it as its own change.

`GamesManagement.tsx` carries the same pattern with its own magic number but is not referenced by any route, so it's untouched here.

## Verified

- dead strip is 0px on all three pages, at 1280x720, 1280x560 and 375x812
- `npx tsc -b` clean, `npm run build` OK
- `./run-test.sh --no-ai` — 249 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)